### PR TITLE
chore(release): 2.0.0-beta.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "tglock"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "aes",
  "cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tglock"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 edition = "2021"
 rust-version = "1.88"
 description = "Telegram unblock via local WebSocket tunnel"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tglock-ui",
   "private": true,
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1420",

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TGLock",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "identifier": "com.bysonic.tglock",
   "mainBinaryName": "tglock",
   "build": {


### PR DESCRIPTION
Подъём версии в `Cargo.toml`, `tauri.conf.json` и `package.json` под выпуск 2.0.0-beta.9.

Содержимое выпуска — #43: LAN-режим отклонял настоящие адреса Telegram (#42), список сетей теперь опубликованный самим Telegram, добавлены IPv6 и имена веб-инфраструктуры, появился счётчик «Отклонено» в диагностике и в строке статуса CLI.

После мержа тег ставится на HEAD `main` и в `main` до конца сборки ничего не пушится — порядок из docs/RELEASING.md.