### PR TITLE
chore(release): 2.0.0-beta.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "tglock"
-version = "2.0.0-beta.9"
+version = "2.0.0-beta.10"
 dependencies = [
  "aes",
  "cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tglock"
-version = "2.0.0-beta.9"
+version = "2.0.0-beta.10"
 edition = "2021"
 rust-version = "1.88"
 description = "Telegram unblock via local WebSocket tunnel"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tglock-ui",
   "private": true,
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1420",

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TGLock",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "identifier": "com.bysonic.tglock",
   "mainBinaryName": "tglock",
   "build": {


### PR DESCRIPTION
Подъём версии под выпуск 2.0.0-beta.10.

Содержимое — #45: клиент, который дошёл до прокси, но не сумел договориться, закрывался молча и не попадал ни в один счётчик. Теперь его считает `unknown_clients`, а журнал называет адрес и причину.

Дальше по docs/RELEASING.md: тег на HEAD `main`, в `main` до конца сборки не пушим.