### PR TITLE
GUI: стабильный секрет прокси и видимая tg:// ссылка

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ rust-version = "1.88"
 description = "Telegram unblock via local WebSocket tunnel"
 license = "MIT"
 autobins = false
+default-run = "tglock"
 
 [features]
 default = ["gui"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ impl Default for Settings {
             lan_mode: false,
             port: proxy::DEFAULT_PORT,
             worker_domain: String::new(),
+            secret: None,
         }
     }
 }
@@ -558,8 +559,9 @@ mod tests {
 
     #[test]
     fn file_backed_secret_survives_restarts() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let secret_path = dir.path().join("secret");
+        let dir = std::env::temp_dir().join(format!("tglock-secret-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        let secret_path = dir.join("secret");
         let settings = Settings::default();
         let first = build_stats(&settings, &secret_path);
         let second = build_stats(&settings, &secret_path);
@@ -572,6 +574,7 @@ mod tests {
             first.secret_write_error().is_none(),
             "fresh tempdir must allow writing the secret"
         );
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tauri::{Manager, State};
 use tglock::config::ListenConfig;
-use tglock::{proxy, transport};
+use tglock::{mtproto, proxy, transport};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -15,6 +15,9 @@ struct Settings {
     lan_mode: bool,
     port: u16,
     worker_domain: String,
+    /// Зафиксированный секрет прокси (32 hex или dd…). Пусто — из файла secret рядом с settings.json.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    secret: Option<String>,
 }
 
 impl Default for Settings {
@@ -65,11 +68,18 @@ struct StatusSnapshot {
     /// телефоне или в эмуляторе означает само устройство, и подключение не
     /// работало (by-sonic/tglock#36).
     share_address: Option<String>,
+    /// Полная ссылка tg://proxy для этого экземпляра. Нужна, чтобы заново
+    /// подключить Telegram после перезапуска (by-sonic/tglock#37).
+    telegram_link: Option<String>,
+    /// Секрет записан на диск и переживёт перезапуск.
+    secret_persistent: bool,
+    /// Почему секрет не сохранился — после перезапуска ссылка изменится.
+    secret_write_error: Option<String>,
     logs: Vec<LogLine>,
 }
 
 struct AppState {
-    stats: Arc<proxy::Stats>,
+    stats: Mutex<Arc<proxy::Stats>>,
     settings: Mutex<Settings>,
     active_port: Mutex<u16>,
     /// Слушатель работающего прокси. Нужен, чтобы показать адрес для других
@@ -79,6 +89,7 @@ struct AppState {
     started_at: Mutex<Option<Instant>>,
     logs: Arc<Mutex<Vec<LogLine>>>,
     settings_path: PathBuf,
+    secret_path: PathBuf,
 }
 
 impl AppState {
@@ -87,15 +98,26 @@ impl AppState {
             .ok()
             .and_then(|contents| serde_json::from_slice(&contents).ok())
             .unwrap_or_default();
+        let secret_path = gui_secret_path(&settings_path);
+        migrate_legacy_secret(&secret_path);
         Self {
-            stats: proxy::Stats::new(),
+            stats: Mutex::new(build_stats(&settings, &secret_path)),
             settings: Mutex::new(settings),
             active_port: Mutex::new(proxy::DEFAULT_PORT),
             active_listen: Mutex::new(None),
             started_at: Mutex::new(None),
             logs: Arc::new(Mutex::new(Vec::new())),
             settings_path,
+            secret_path,
         }
+    }
+
+    fn stats(&self) -> Arc<proxy::Stats> {
+        self.stats.lock().unwrap().clone()
+    }
+
+    fn replace_stats(&self, settings: &Settings) {
+        *self.stats.lock().unwrap() = build_stats(settings, &self.secret_path);
     }
 
     fn log(&self, message: impl Into<String>, error: bool) {
@@ -111,30 +133,38 @@ impl AppState {
     }
 
     fn snapshot(&self) -> StatusSnapshot {
+        let stats = self.stats();
         // События прокси доходят до журнала только здесь: у ядра нет своего
         // способа что-то показать, а интерфейс и так опрашивает состояние.
-        for event in self.stats.drain_events() {
+        for event in stats.drain_events() {
             self.log(event, false);
         }
-        let data_center = self.stats.last_dc();
-        let route = transport::route_label(self.stats.last_route());
+        let data_center = stats.last_dc();
+        let route = transport::route_label(stats.last_route());
+        let active_listen = *self.active_listen.lock().unwrap();
+        let settings = self.settings.lock().unwrap().clone();
+        let listen = active_listen.unwrap_or_else(|| listen_from_settings(&settings));
+        let secret_write_error = stats.secret_write_error().map(str::to_owned);
         StatusSnapshot {
-            running: self.stats.running.load(Ordering::SeqCst),
-            active_connections: self.stats.active.load(Ordering::Relaxed),
-            tunnels: self.stats.ws.load(Ordering::Relaxed),
+            running: stats.running.load(Ordering::SeqCst),
+            active_connections: stats.active.load(Ordering::Relaxed),
+            tunnels: stats.ws.load(Ordering::Relaxed),
             data_center: (data_center > 0).then_some(data_center),
             route: route.to_owned(),
-            failures: self.stats.ws_failures.load(Ordering::Relaxed),
-            route_failures: self.stats.route_failures(),
-            blocked: self.stats.blocked.load(Ordering::Relaxed),
-            unknown_clients: self.stats.unknown_clients.load(Ordering::Relaxed),
+            failures: stats.ws_failures.load(Ordering::Relaxed),
+            route_failures: stats.route_failures(),
+            blocked: stats.blocked.load(Ordering::Relaxed),
+            unknown_clients: stats.unknown_clients.load(Ordering::Relaxed),
             uptime_seconds: self
                 .started_at
                 .lock()
                 .unwrap()
                 .map_or(0, |started| started.elapsed().as_secs()),
             port: *self.active_port.lock().unwrap(),
-            share_address: share_address(*self.active_listen.lock().unwrap()),
+            share_address: share_address(active_listen),
+            telegram_link: Some(telegram_link(listen, &stats)),
+            secret_persistent: settings.secret.is_some() || secret_write_error.is_none(),
+            secret_write_error,
             logs: self.logs.lock().unwrap().clone(),
         }
     }
@@ -149,6 +179,78 @@ impl AppState {
         std::fs::write(&self.settings_path, contents)
             .map_err(|error| format!("Не удалось сохранить настройки: {error}"))
     }
+}
+
+fn gui_secret_path(settings_path: &Path) -> PathBuf {
+    settings_path
+        .parent()
+        .map(|dir| dir.join("secret"))
+        .unwrap_or_else(|| PathBuf::from("secret"))
+}
+
+#[cfg(not(test))]
+fn legacy_secret_path() -> Option<PathBuf> {
+    mtproto::default_secret_path()
+}
+
+#[cfg(test)]
+fn legacy_secret_path() -> Option<PathBuf> {
+    None
+}
+
+fn migrate_legacy_secret(target: &Path) {
+    if target.exists() {
+        return;
+    }
+    let Some(legacy) = legacy_secret_path() else {
+        return;
+    };
+    if !legacy.exists() {
+        return;
+    }
+    let Ok(contents) = std::fs::read_to_string(&legacy) else {
+        return;
+    };
+    if mtproto::parse_secret(contents.trim()).is_none() {
+        return;
+    }
+    if let Some(parent) = target.parent().filter(|path| !path.as_os_str().is_empty()) {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::copy(&legacy, target);
+}
+
+fn normalize_settings_secret(settings: &mut Settings) -> Result<(), String> {
+    if let Some(secret) = settings.secret.as_ref() {
+        let trimmed = secret.trim();
+        if trimmed.is_empty() {
+            settings.secret = None;
+        } else {
+            let parsed = mtproto::parse_secret(trimmed)
+                .ok_or_else(|| "Секрет: 32 hex-символа или dd…".to_string())?;
+            settings.secret = Some(mtproto::telegram_secret(&parsed));
+        }
+    }
+    Ok(())
+}
+
+fn build_stats(settings: &Settings, secret_path: &Path) -> Arc<proxy::Stats> {
+    if let Some(secret) = settings.secret.as_deref().and_then(mtproto::parse_secret) {
+        return proxy::Stats::with_secret(secret);
+    }
+    proxy::Stats::with_stored_secret(mtproto::load_or_create_secret_at(secret_path))
+}
+
+fn listen_from_settings(settings: &Settings) -> ListenConfig {
+    if settings.lan_mode {
+        ListenConfig::lan(settings.port)
+    } else {
+        ListenConfig::loopback(settings.port)
+    }
+}
+
+fn telegram_link(listen: ListenConfig, stats: &proxy::Stats) -> String {
+    listen.telegram_link(&stats.telegram_secret())
 }
 
 /// Адрес, который нужно вписать в Telegram на другом устройстве.
@@ -188,26 +290,30 @@ fn get_settings(state: State<'_, AppState>) -> Settings {
 
 #[tauri::command]
 fn save_settings(settings: Settings, state: State<'_, AppState>) -> Result<Settings, String> {
-    if state.stats.running.load(Ordering::SeqCst) {
+    if state.stats().running.load(Ordering::SeqCst) {
         return Err("Сначала выключите защиту".into());
     }
     if settings.port == 0 {
         return Err("Порт должен быть от 1 до 65535".into());
     }
+    let mut settings = settings;
+    normalize_settings_secret(&mut settings)?;
     state.persist_settings(&settings)?;
     *state.settings.lock().unwrap() = settings.clone();
+    state.replace_stats(&settings);
     state.log("Настройки сохранены", false);
     Ok(settings)
 }
 
 #[tauri::command]
 fn start_proxy(state: State<'_, AppState>) -> Result<StatusSnapshot, String> {
-    if state.stats.running.load(Ordering::SeqCst) {
+    if state.stats().running.load(Ordering::SeqCst) {
         return Ok(state.snapshot());
     }
 
     let settings = state.settings.lock().unwrap().clone();
-    state.stats.set_worker_domain(&settings.worker_domain);
+    let stats = state.stats();
+    stats.set_worker_domain(&settings.worker_domain);
     *state.active_port.lock().unwrap() = settings.port;
     *state.started_at.lock().unwrap() = Some(Instant::now());
     state.log("Запускаю защищённый маршрут…", false);
@@ -220,7 +326,6 @@ fn start_proxy(state: State<'_, AppState>) -> Result<StatusSnapshot, String> {
 
     *state.active_listen.lock().unwrap() = Some(listen);
 
-    let stats = state.stats.clone();
     let logs = state.logs.clone();
     std::thread::spawn(move || {
         let runtime = match tokio::runtime::Runtime::new() {
@@ -236,7 +341,7 @@ fn start_proxy(state: State<'_, AppState>) -> Result<StatusSnapshot, String> {
     });
 
     std::thread::sleep(std::time::Duration::from_millis(220));
-    if !state.stats.running.load(Ordering::SeqCst) {
+    if !state.stats().running.load(Ordering::SeqCst) {
         *state.active_listen.lock().unwrap() = None;
         *state.started_at.lock().unwrap() = None;
         return Err(state
@@ -249,14 +354,15 @@ fn start_proxy(state: State<'_, AppState>) -> Result<StatusSnapshot, String> {
     }
 
     state.log(format!("Прокси запущен на {}", listen.addr), false);
-    let _ = open::that(listen.telegram_link(&state.stats.telegram_secret()));
+    let stats = state.stats();
+    let _ = open::that(listen.telegram_link(&stats.telegram_secret()));
     state.log("Открываю подключение в Telegram…", false);
     Ok(state.snapshot())
 }
 
 #[tauri::command]
 fn stop_proxy(state: State<'_, AppState>) -> StatusSnapshot {
-    state.stats.stop();
+    state.stats().stop();
     *state.active_listen.lock().unwrap() = None;
     *state.started_at.lock().unwrap() = None;
     state.log("Защита выключена", false);
@@ -332,7 +438,7 @@ fn main() {
             // Если секрет не удалось записать, ссылка tg://proxy изменится после
             // перезапуска и Telegram откажется подключаться к сохранённой.
             // Раньше это происходило молча (by-sonic/tglock#37).
-            if let Some(error) = state.stats.secret_write_error() {
+            if let Some(error) = state.stats().secret_write_error() {
                 state.log(
                     format!("Секрет не сохранён ({error}). После перезапуска ссылка изменится"),
                     true,
@@ -424,5 +530,57 @@ mod tests {
                 ]
             );
         }
+    }
+
+    #[test]
+    fn gui_secret_lives_next_to_settings() {
+        let settings = PathBuf::from("/tmp/tglock/settings.json");
+        assert_eq!(
+            gui_secret_path(&settings),
+            PathBuf::from("/tmp/tglock/secret")
+        );
+    }
+
+    #[test]
+    fn pinned_secret_is_normalized_to_telegram_form() {
+        let mut settings = Settings {
+            lan_mode: false,
+            port: 1080,
+            worker_domain: String::new(),
+            secret: Some("abababababababababababababababab".into()),
+        };
+        normalize_settings_secret(&mut settings).expect("valid hex secret");
+        assert_eq!(
+            settings.secret.as_deref(),
+            Some("ddabababababababababababababababab")
+        );
+    }
+
+    #[test]
+    fn file_backed_secret_survives_restarts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let secret_path = dir.path().join("secret");
+        let settings = Settings::default();
+        let first = build_stats(&settings, &secret_path);
+        let second = build_stats(&settings, &secret_path);
+        assert_eq!(
+            first.telegram_secret(),
+            second.telegram_secret(),
+            "secret file must pin tg://proxy across restarts"
+        );
+        assert!(
+            first.secret_write_error().is_none(),
+            "fresh tempdir must allow writing the secret"
+        );
+    }
+
+    #[test]
+    fn telegram_link_uses_the_same_secret_as_stats() {
+        let stats = proxy::Stats::with_secret([0xab; 16]);
+        let listen = ListenConfig::loopback(1080);
+        assert_eq!(
+            telegram_link(listen, &stats),
+            listen.telegram_link(&stats.telegram_secret())
+        );
     }
 }

--- a/src/mtproto.rs
+++ b/src/mtproto.rs
@@ -113,6 +113,11 @@ pub fn load_or_create_secret() -> StoredSecret {
 }
 
 #[cfg(not(test))]
+pub fn default_secret_path() -> Option<PathBuf> {
+    secret_path()
+}
+
+#[cfg(not(test))]
 fn secret_path() -> Option<PathBuf> {
     #[cfg(target_os = "windows")]
     {

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -81,6 +81,19 @@ function escapeHtml(value: string): string {
     .replaceAll('"', "&quot;");
 }
 
+function formatTelegramLinkPreview(link: string): string {
+  const match = link.match(/^tg:\/\/proxy\?server=([^&]+)&port=(\d+)&secret=([a-f0-9]+)$/i);
+  if (match) {
+    const [, server, port, secret] = match;
+    const secretPreview = secret.length > 10 ? `${secret.slice(0, 2)}…${secret.slice(-6)}` : secret;
+    return `${server}:${port} · secret ${secretPreview}`;
+  }
+  if (link.length > 48) {
+    return `${link.slice(0, 22)}…${link.slice(-14)}`;
+  }
+  return link;
+}
+
 function formatUptime(seconds: number): string {
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
@@ -176,15 +189,17 @@ function renderHome(): void {
       </div>` : ""}
 
       ${status.telegramLink ? `
-      <div class="share-card">
-        <div class="share-label">Ссылка для Telegram</div>
-        <button id="copy-link" class="share-address" title="Нажмите, чтобы скопировать">
-          ${escapeHtml(status.telegramLink)}
-        </button>
-        <div class="share-hint">
-          Откройте её в Telegram на этом или другом устройстве. Если прокси «настроен неверно» —
-          скопируйте ссылку заново: секрет мог измениться после прошлого запуска.
+      <div class="proxy-link-card">
+        <div class="proxy-link-head">
+          <span class="proxy-link-label">Ссылка для Telegram</span>
+          <button id="copy-link" type="button" class="copy-chip">Копировать</button>
         </div>
+        <div class="proxy-link-preview" title="${escapeHtml(status.telegramLink)}">
+          ${escapeHtml(formatTelegramLinkPreview(status.telegramLink))}
+        </div>
+        <p class="proxy-link-hint">${status.secretPersistent
+          ? "Вставьте ссылку в Telegram или откройте её на телефоне."
+          : "Секрет может меняться — скопируйте ссылку заново после перезапуска."}</p>
       </div>` : ""}
 
       ${status.shareAddress ? `

--- a/ui/main.ts
+++ b/ui/main.ts
@@ -19,6 +19,12 @@ type Status = {
   port: number;
   /// Адрес для других устройств. Приходит только в LAN-режиме.
   shareAddress: string | null;
+  /// Полная ссылка tg://proxy для подключения Telegram.
+  telegramLink: string | null;
+  /// Секрет сохранён и не изменится после перезапуска.
+  secretPersistent: boolean;
+  /// Почему секрет не записался на диск.
+  secretWriteError: string | null;
   logs: LogLine[];
 };
 
@@ -32,6 +38,7 @@ type Settings = {
   lanMode: boolean;
   port: number;
   workerDomain: string;
+  secret?: string | null;
 };
 
 const root = document.querySelector<HTMLDivElement>("#app")!;
@@ -50,6 +57,9 @@ let status: Status = {
   uptimeSeconds: 0,
   port: 1080,
   shareAddress: null,
+  telegramLink: null,
+  secretPersistent: true,
+  secretWriteError: null,
   logs: [],
 };
 let settings: Settings = { lanMode: false, port: 1080, workerDomain: "" };
@@ -156,6 +166,27 @@ function renderHome(): void {
         <span>порт ${status.port}</span>
       </div>
 
+      ${status.secretWriteError || !status.secretPersistent ? `
+      <div class="notice-card warning">
+        <strong>Секрет не сохранён</strong>
+        <p>${status.secretWriteError
+          ? escapeHtml(status.secretWriteError)
+          : "После перезапуска ссылка tg://proxy изменится, и Telegram откажет старой."}</p>
+        <p class="field-hint">Закрепите секрет в настройках или проверьте права на папку приложения.</p>
+      </div>` : ""}
+
+      ${status.telegramLink ? `
+      <div class="share-card">
+        <div class="share-label">Ссылка для Telegram</div>
+        <button id="copy-link" class="share-address" title="Нажмите, чтобы скопировать">
+          ${escapeHtml(status.telegramLink)}
+        </button>
+        <div class="share-hint">
+          Откройте её в Telegram на этом или другом устройстве. Если прокси «настроен неверно» —
+          скопируйте ссылку заново: секрет мог измениться после прошлого запуска.
+        </div>
+      </div>` : ""}
+
       ${status.shareAddress ? `
       <div class="share-card">
         <div class="share-label">Адрес для других устройств</div>
@@ -183,6 +214,7 @@ function renderHome(): void {
   `, "home-page");
 
   document.querySelector("#power")?.addEventListener("click", toggleProtection);
+  document.querySelector("#copy-link")?.addEventListener("click", copyTelegramLink);
   document.querySelector("#copy-address")?.addEventListener("click", copyShareAddress);
   document.querySelector("#settings-nav")?.addEventListener("click", () => navigate("settings"));
   document.querySelector("#diagnostics-nav")?.addEventListener("click", () => navigate("diagnostics"));
@@ -218,6 +250,24 @@ function renderSettings(): void {
             ${status.running ? "disabled" : ""}
           />
           <p class="field-hint">Необязательно. Используется как резервный маршрут.</p>
+        </div>
+
+        <div class="setting-card">
+          <label class="field-label" for="secret">Секрет прокси</label>
+          <input
+            id="secret"
+            name="secret"
+            type="text"
+            value="${escapeHtml(settings.secret ?? "")}"
+            placeholder="dd… или 32 hex (необязательно)"
+            autocomplete="off"
+            spellcheck="false"
+            ${status.running ? "disabled" : ""}
+          />
+          <p class="field-hint">
+            Пусто — секрет хранится в файле рядом с настройками. Закрепите вручную, если Telegram
+            отвергает прокси после перезапуска.
+          </p>
         </div>
 
         <div class="setting-list">
@@ -384,9 +434,10 @@ async function saveSettings(event: Event): Promise<void> {
   event.preventDefault();
   if (busy || status.running) return;
   const worker = document.querySelector<HTMLInputElement>("#worker");
+  const secret = document.querySelector<HTMLInputElement>("#secret");
   const lanMode = document.querySelector<HTMLInputElement>("#lan-mode");
   const port = document.querySelector<HTMLInputElement>("#port");
-  if (!worker || !lanMode || !port) return;
+  if (!worker || !secret || !lanMode || !port) return;
 
   const parsedPort = Number(port.value);
   if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
@@ -399,6 +450,7 @@ async function saveSettings(event: Event): Promise<void> {
     workerDomain: worker.value.trim(),
     lanMode: lanMode.checked,
     port: parsedPort,
+    secret: secret.value.trim() || null,
   };
   renderSettings();
   try {
@@ -409,6 +461,17 @@ async function saveSettings(event: Event): Promise<void> {
     showToast(String(error), true);
   } finally {
     busy = false;
+  }
+}
+
+async function copyTelegramLink(): Promise<void> {
+  const link = status.telegramLink;
+  if (!link) return;
+  try {
+    await navigator.clipboard.writeText(link);
+    showToast("Ссылка скопирована");
+  } catch {
+    showToast("Скопируйте ссылку вручную", true);
   }
 }
 

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -898,6 +898,68 @@ input:disabled {
   font-size: 11px;
 }
 
+.proxy-link-card {
+  margin-top: 14px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(17, 24, 37, 0.54);
+  border: 1px solid var(--line);
+  text-align: left;
+}
+
+.proxy-link-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.proxy-link-label {
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--text-muted, #8b949e);
+}
+
+.copy-chip {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid rgba(42, 171, 238, 0.35);
+  border-radius: 999px;
+  background: rgba(42, 171, 238, 0.12);
+  color: var(--accent, #2aabee);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.copy-chip:hover,
+.copy-chip:focus-visible {
+  background: rgba(42, 171, 238, 0.22);
+  border-color: rgba(42, 171, 238, 0.55);
+}
+
+.proxy-link-preview {
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.22);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.35;
+  color: #b8c8dc;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.proxy-link-hint {
+  margin: 8px 0 0;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--text-muted, #8b949e);
+}
+
 .notice-card {
   margin-top: 14px;
   padding: 14px 16px;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -897,3 +897,28 @@ input:disabled {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 11px;
 }
+
+.notice-card {
+  margin-top: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  text-align: left;
+}
+
+.notice-card.warning {
+  background: rgba(255, 191, 91, 0.1);
+  border: 1px solid rgba(255, 191, 91, 0.35);
+}
+
+.notice-card strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+
+.notice-card p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-muted, #8b949e);
+}


### PR DESCRIPTION
## Summary
- Секрет GUI хранится в \{app_config_dir}/secret\ рядом с \settings.json\, с миграцией со старого пути (\%APPDATA%\\TGLock\\secret\).
- В статус добавлены \	elegramLink\, \secretPersistent\, \secretWriteError\.
- На главном экране — предупреждение при неперсистентном секрете и кнопка копирования \	g://proxy\.
- В настройках — опциональный pin секрета (32 hex или \dd…\), как в CLI.

Fixes by-sonic/tglock#37 (stale secret / proxy rejected after restart).

## Test plan
- [x] \cargo test --lib\ — 69 passed
- [x] \cargo test --bin tglock\ — 10 passed
- [x] Запустить GUI, включить защиту, перезапустить приложение — ссылка \	g://proxy\ не меняется
- [x] Telegram подключается без «прокси настроен неверно»
