### PR TITLE
chore(release): 2.0.0-beta.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "tglock"
-version = "2.0.0-beta.12"
+version = "2.0.0-beta.13"
 dependencies = [
  "aes",
  "cipher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tglock"
-version = "2.0.0-beta.12"
+version = "2.0.0-beta.13"
 edition = "2021"
 rust-version = "1.88"
 description = "Telegram unblock via local WebSocket tunnel"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tglock-ui",
   "private": true,
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "type": "module",
   "scripts": {
     "dev": "vite --port 1420",

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TGLock",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "identifier": "com.bysonic.tglock",
   "mainBinaryName": "tglock",
   "build": {


### PR DESCRIPTION
Подъём версии до 2.0.0-beta.13 в `Cargo.toml`, `tauri.conf.json`, `package.json` и `Cargo.lock`.

Содержимое релиза — #54: причина отказа каскада маршрутов и судьба домена Cloudflare Worker'а больше не пропадают молча (#50).